### PR TITLE
Fix structure-factor calls to pass rotation matrices into calc_power_dwf_aniso

### DIFF
--- a/cryspy/A_functions_base/debye_waller_factor.py
+++ b/cryspy/A_functions_base/debye_waller_factor.py
@@ -185,9 +185,9 @@ def calc_power_dwf_aniso(
     k = index_hkl[1]
     l = index_hkl[2]
 
-    r_11, r_12, r_13 = symm_elems_r[0], symm_elems_r[1], symm_elems_r[2]
-    r_21, r_22, r_23 = symm_elems_r[3], symm_elems_r[4], symm_elems_r[5]
-    r_31, r_32, r_33 = symm_elems_r[6], symm_elems_r[7], symm_elems_r[8]
+    r_11, r_12, r_13 = symm_elems_r[4], symm_elems_r[5], symm_elems_r[6]
+    r_21, r_22, r_23 = symm_elems_r[7], symm_elems_r[8], symm_elems_r[9]
+    r_31, r_32, r_33 = symm_elems_r[10], symm_elems_r[11], symm_elems_r[12]
 
     h_s = h*r_11 + k*r_21 + l*r_31
     k_s = h*r_12 + k*r_22 + l*r_32

--- a/cryspy/A_functions_base/debye_waller_factor.py
+++ b/cryspy/A_functions_base/debye_waller_factor.py
@@ -185,9 +185,9 @@ def calc_power_dwf_aniso(
     k = index_hkl[1]
     l = index_hkl[2]
 
-    r_11, r_12, r_13 = symm_elems_r[4], symm_elems_r[5], symm_elems_r[6]
-    r_21, r_22, r_23 = symm_elems_r[7], symm_elems_r[8], symm_elems_r[9]
-    r_31, r_32, r_33 = symm_elems_r[10], symm_elems_r[11], symm_elems_r[12]
+    r_11, r_12, r_13 = symm_elems_r[0], symm_elems_r[1], symm_elems_r[2]
+    r_21, r_22, r_23 = symm_elems_r[3], symm_elems_r[4], symm_elems_r[5]
+    r_31, r_32, r_33 = symm_elems_r[6], symm_elems_r[7], symm_elems_r[8]
 
     h_s = h*r_11 + k*r_21 + l*r_31
     k_s = h*r_12 + k*r_22 + l*r_32
@@ -238,4 +238,3 @@ def calc_dwf(index_hkl, sthovl, b_iso, beta, symm_elems_r,
     if flag_beta:
         dder["beta"] = None
     return dwf, dder
-

--- a/cryspy/A_functions_base/structure_factor.py
+++ b/cryspy/A_functions_base/structure_factor.py
@@ -502,7 +502,7 @@ def calc_f_nucl(index_hkl,
     else:
         debye_waller_factor, dder_dw = calc_dwf(
             index_hkl[:, :, na, na], sthovl[:, na, na], atom_b_iso[na, na, :],
-            atom_beta[:, na, na, :], reduced_symm_elems[:, na, :, na],
+            atom_beta[:, na, na, :], reduced_symm_elems[4:13, na, :, na],
             flag_sthovl=flag_sthovl, flag_b_iso=flag_atom_b_iso, flag_beta=flag_atom_beta)
         if flag_dict:
             dict_in_out["debye_waller_factor"] = debye_waller_factor
@@ -729,7 +729,7 @@ def calc_f_charge(index_hkl,
     else:
         debye_waller_factor, dder_dw = calc_dwf(
             index_hkl[:, :, na, na], sthovl[:, na, na], atom_b_iso[na, na, :],
-            atom_beta[:, na, na, :], reduced_symm_elems[:, na, :, na],
+            atom_beta[:, na, na, :], reduced_symm_elems[4:13, na, :, na],
             flag_sthovl=flag_sthovl, flag_b_iso=flag_atom_b_iso, flag_beta=flag_atom_beta)
         if flag_dict:
             dict_in_out["debye_waller_factor"] = debye_waller_factor
@@ -1007,7 +1007,7 @@ def calc_sft_ccs(index_hkl,
     else:
         debye_waller_factor, dder_dw = calc_dwf(
             index_hkl[:, :, na, na], sthovl[:, na, na], atom_para_b_iso[na, na, :],
-            atom_para_beta[:, na, na, :], reduced_symm_elems[:13, na, :, na],
+            atom_para_beta[:, na, na, :], reduced_symm_elems[4:13, na, :, na],
             flag_sthovl=flag_sthovl, flag_b_iso=flag_atom_para_b_iso, flag_beta=flag_atom_para_beta)
         if flag_dict:
             dict_in_out["atom_para_debye_waller_factor"] = debye_waller_factor
@@ -1268,7 +1268,7 @@ def calc_f_m_perp_ordered(index_hkl,
     else:
         debye_waller_factor, dder_dw = calc_dwf(
             index_hkl[:, :, na, na], sthovl[:, na, na], atom_ordered_b_iso[na, na, :],
-            atom_ordered_beta[:, na, na, :], full_mcif_elems[:13, na, :, na],
+            atom_ordered_beta[:, na, na, :], full_mcif_elems[4:13, na, :, na],
             flag_sthovl=flag_sthovl, flag_b_iso=flag_atom_ordered_b_iso, flag_beta=flag_atom_ordered_beta)
         if flag_dict:
             dict_in_out["atom_ordered_debye_waller_factor"] = debye_waller_factor

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
@@ -24,6 +26,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/cf/00ba28b0990982530addb8dc3e9e6f2fa9cb5c20df2abdda7baa755e8fe1/fonttools-4.61.1-cp313-cp313-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/7a/9d90a151f558e29c3936b8a47ac770235f436f2120aca41a6d5f3d62ae8d/kiwisolver-1.4.9-cp313-cp313-macosx_11_0_arm64.whl
@@ -37,6 +40,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8b/40/2614036cdd416452f5bf98ec037f38a1afb17f327cb8e6b652d4729e0af8/pyparsing-3.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/13/7e63cfba8a7452eb756306aa2fd9b37a29a323b672b964b4fdeded9a3f21/scipy-1.16.3-cp313-cp313-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -88,14 +92,13 @@ packages:
   requires_python: '>=3.11'
 - pypi: ./
   name: cryspy
-  version: 0.9.2
-  sha256: 850922bbd246a840b209eb636843668b85fa6f88b4db9d65dabb6034cd2d3583
+  version: 0.10.0
+  sha256: 58f1af928038b23dc4cf0928a643194d4bbdb95c13d9b73f658031ed3bfcfd92
   requires_dist:
   - numpy
   - scipy
   - pycifstar
   - matplotlib
-  editable: true
 - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
   name: cycler
   version: 0.12.1
@@ -108,6 +111,16 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   - pytest-xdist ; extra == 'tests'
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl
+  name: execnet
+  version: 2.1.2
+  sha256: 67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
+  requires_dist:
+  - hatch ; extra == 'testing'
+  - pre-commit ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - tox ; extra == 'testing'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/4b/cf/00ba28b0990982530addb8dc3e9e6f2fa9cb5c20df2abdda7baa755e8fe1/fonttools-4.61.1-cp313-cp313-macosx_10_13_universal2.whl
   name: fonttools
@@ -354,6 +367,17 @@ packages:
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl
+  name: pytest-xdist
+  version: 3.8.0
+  sha256: 202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88
+  requires_dist:
+  - execnet>=2.1
+  - pytest>=7.0.0
+  - filelock ; extra == 'testing'
+  - psutil>=3.0 ; extra == 'psutil'
+  - setproctitle ; extra == 'setproctitle'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.11-hfc2f54d_100_cp313.conda
   build_number: 100
   sha256: c476f4e9b6d97c46b496b442878924868a54e5727251549ebfc82027aa52af68

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,6 +18,7 @@ pycifstar = "*"
 pyparsing = "*"
 python-dateutil = "*"
 pytest = "*"
+pytest-xdist = "*"
 scipy = "*"
 six = "*"
 cryspy = { path = ".", editable = true }

--- a/tests/basic_operations/test_debye_waller_factor.py
+++ b/tests/basic_operations/test_debye_waller_factor.py
@@ -7,10 +7,7 @@ from cryspy.A_functions_base.debye_waller_factor import \
     calc_power_dwf_iso, \
     calc_power_dwf_aniso, \
     calc_dwf
-from cryspy.A_functions_base.unit_cell import (
-    calc_reciprocal_by_unit_cell_parameters,
-    calc_sthovl_by_unit_cell_parameters,
-)
+
 
 na = numpy.newaxis
 

--- a/tests/basic_operations/test_debye_waller_factor.py
+++ b/tests/basic_operations/test_debye_waller_factor.py
@@ -41,7 +41,12 @@ index_hkl = numpy.array([
     [0, 2, 0, 2, 2, 2, 2, 2, 3, 3, 3],
     [2, 0, 0, 2, 3, 4, 5, 6, 3, 2, 3]], dtype=int)
 
-
+symm_elems_t = numpy.array([
+    [0, 0, 0, 0],  # b_1
+    [0, 0, 0, 0],  # b_2
+    [0, 0, 0, 0],  # b_3
+    [1, 1, 1, 1],  # b_d
+], dtype=int)
 
 symm_elems_r = numpy.array([
     [1,-1,-1, 1],
@@ -54,6 +59,7 @@ symm_elems_r = numpy.array([
     [0, 0, 0, 0],
     [1,-1, 1,-1]], dtype=int)
 
+symm_elems = numpy.vstack([symm_elems_t, symm_elems_r])
 
 beta_ij = numpy.array(
     [0.17765288,  0.01063943,  0.37899281,  0.01658094, -0.16580935, -0.11053957],
@@ -270,7 +276,7 @@ def test_calc_power_dwf_iso():
 
 
 def test_calc_power_dwf_aniso():
-    res, dder = calc_power_dwf_aniso(index_hkl[:, :, na, na], beta[:, na, :, na], symm_elems_r[:, na, na, :], flag_beta=True)
+    res, dder = calc_power_dwf_aniso(index_hkl[:, :, na, na], beta[:, na, :, na], symm_elems[:, na, na, :], flag_beta=True)
     print("res: ", res)
     print(power_dwf_aniso)
 
@@ -279,7 +285,7 @@ def test_calc_power_dwf_aniso():
 
 def test_calc_dwf():
     res, dder = calc_dwf(
-        index_hkl[:, :, na, na], sthovl[:, na, na], b_iso[na, :, na], beta[:, na, :, na], symm_elems_r[:, na, na, :],
+        index_hkl[:, :, na, na], sthovl[:, na, na], b_iso[na, :, na], beta[:, na, :, na], symm_elems[:, na, na, :],
         flag_sthovl=True, flag_b_iso=True, flag_beta=True)
     print("res: ", res)
     print(dwf)

--- a/tests/basic_operations/test_debye_waller_factor.py
+++ b/tests/basic_operations/test_debye_waller_factor.py
@@ -1,11 +1,16 @@
 import numpy
 
+from cryspy import Cell, SpaceGroup, AtomSiteL, AtomSiteAnisoL, Crystal
 from cryspy.A_functions_base.debye_waller_factor import \
     calc_beta_by_u_ij, \
     calc_b_iso_beta, \
     calc_power_dwf_iso, \
     calc_power_dwf_aniso, \
     calc_dwf
+from cryspy.A_functions_base.unit_cell import (
+    calc_reciprocal_by_unit_cell_parameters,
+    calc_sthovl_by_unit_cell_parameters,
+)
 
 na = numpy.newaxis
 
@@ -251,7 +256,7 @@ def test_calc_b_iso_beta():
     print(b_iso_out)
     print("res_beta: ", res_beta)
     print(beta_out)
-    
+
     assert numpy.all(numpy.isclose(res_b_iso, b_iso_out))
     assert numpy.all(numpy.isclose(res_beta, beta_out))
 
@@ -278,5 +283,65 @@ def test_calc_dwf():
         flag_sthovl=True, flag_b_iso=True, flag_beta=True)
     print("res: ", res)
     print(dwf)
-    
+
     assert numpy.all(numpy.isclose(res, dwf))
+
+
+def test_dwf_iso_equals_dwf_aniso_for_fd3m_8b_special_position():
+    space_group = SpaceGroup(
+        name_hm_alt="F d -3 m",
+        it_coordinate_system_code="2",
+    )
+
+    crystal_iso = Crystal(
+        cell=Cell(),
+        space_group=space_group,
+        atom_site=AtomSiteL(
+            label=["C"],
+            type_symbol=["C"],
+            fract_x=[0.375],
+            fract_y=[0.375],
+            fract_z=[0.375],
+            adp_type=["Uiso"],
+            u_iso_or_equiv=[0.01],
+        ),
+    )
+    crystal_iso.apply_constraints()
+
+    crystal_ani = Crystal(
+        cell=Cell(),
+        space_group=space_group,
+        atom_site=AtomSiteL(
+            label=["C"],
+            type_symbol=["C"],
+            fract_x=[0.375],
+            fract_y=[0.375],
+            fract_z=[0.375],
+            adp_type=["Uani"],
+        ),
+        atom_site_aniso=AtomSiteAnisoL(
+            label=["C"],
+            u_11=[0.01],
+            u_22=[0.02],
+            u_33=[0.03],
+            u_12=[0.004],
+            u_13=[0.005],
+            u_23=[0.006],
+        ),
+    )
+    crystal_ani.apply_constraints()
+
+    u_iso = crystal_iso.atom_site["C"].u_iso_or_equiv
+    ani = crystal_ani.atom_site_aniso["C"]
+
+    # Special-position constraints should force isotropic U
+    assert ani.u_11 == ani.u_22 == ani.u_33 == u_iso
+    assert ani.u_12 == ani.u_13 == ani.u_23 == 0.0
+
+    index_hkl = numpy.array([[1], [1], [1]], dtype=int)
+
+    f_nuc_iso = crystal_iso.calc_f_nucl(index_hkl)
+    f_nuc_ani = crystal_ani.calc_f_nucl(index_hkl)
+
+    # Nuclear structure factors should be the same
+    assert numpy.allclose(f_nuc_iso, f_nuc_ani, atol=1e-12)

--- a/tests/basic_operations/test_debye_waller_factor.py
+++ b/tests/basic_operations/test_debye_waller_factor.py
@@ -38,13 +38,6 @@ index_hkl = numpy.array([
     [0, 2, 0, 2, 2, 2, 2, 2, 3, 3, 3],
     [2, 0, 0, 2, 3, 4, 5, 6, 3, 2, 3]], dtype=int)
 
-symm_elems_t = numpy.array([
-    [0, 0, 0, 0],  # b_1
-    [0, 0, 0, 0],  # b_2
-    [0, 0, 0, 0],  # b_3
-    [1, 1, 1, 1],  # b_d
-], dtype=int)
-
 symm_elems_r = numpy.array([
     [1,-1,-1, 1],
     [0, 0, 0, 0],
@@ -55,8 +48,6 @@ symm_elems_r = numpy.array([
     [0, 0, 0, 0],
     [0, 0, 0, 0],
     [1,-1, 1,-1]], dtype=int)
-
-symm_elems = numpy.vstack([symm_elems_t, symm_elems_r])
 
 beta_ij = numpy.array(
     [0.17765288,  0.01063943,  0.37899281,  0.01658094, -0.16580935, -0.11053957],
@@ -273,7 +264,7 @@ def test_calc_power_dwf_iso():
 
 
 def test_calc_power_dwf_aniso():
-    res, dder = calc_power_dwf_aniso(index_hkl[:, :, na, na], beta[:, na, :, na], symm_elems[:, na, na, :], flag_beta=True)
+    res, dder = calc_power_dwf_aniso(index_hkl[:, :, na, na], beta[:, na, :, na], symm_elems_r[:, na, na, :], flag_beta=True)
     print("res: ", res)
     print(power_dwf_aniso)
 
@@ -282,7 +273,7 @@ def test_calc_power_dwf_aniso():
 
 def test_calc_dwf():
     res, dder = calc_dwf(
-        index_hkl[:, :, na, na], sthovl[:, na, na], b_iso[na, :, na], beta[:, na, :, na], symm_elems[:, na, na, :],
+        index_hkl[:, :, na, na], sthovl[:, na, na], b_iso[na, :, na], beta[:, na, :, na], symm_elems_r[:, na, na, :],
         flag_sthovl=True, flag_b_iso=True, flag_beta=True)
     print("res: ", res)
     print(dwf)


### PR DESCRIPTION
`reduced_symm_elems` stores translations in rows 0-3 and the rotation matrix in rows 4-12, but `calc_power_dwf_aniso` was reading the rotation from rows 0-8. This mixed translation terms into the rotation matrix and produced incorrect anisotropic Debye-Waller factors.

This PR fixes the indexing and updates the Debye-Waller unit tests to use full 13-row symmetry elements. It also adds a regression test comparing nuclear structure factors for two one-atom crystals that differ only in ADP representation (`Uiso` vs `Uani`). The atom is placed at the `Fd-3m` `8b` special position, where symmetry constrains the anisotropic tensor to an isotropic form (`u11=u22=u33`, `u12=u13=u23=0`), so the `(1 1 1)` structure factor is expected to be identical in both cases.
