### PR TITLE
Add simple non-conv-pseudo-Voigt for TOF

### DIFF
--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -154,6 +154,24 @@ def tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl):
     return tof_peak_2d
 
 
+def tof_non_convoluted_pseudo_voigt(sigma, gamma, time, time_hkl):
+    """Direct symmetric pseudo-Voigt profile in TOF coordinates."""
+    h_g = numpy.sqrt(8.*numpy.log(2.))*sigma
+    h_pv, eta = calc_hpv_eta(h_g, gamma)
+    time_2d, time_hkl_2d = numpy.meshgrid(time, time_hkl, indexing="ij")
+    delta_2d = time_2d-time_hkl_2d
+    delta_over_h_pv = delta_2d/h_pv[:, na]
+
+    profile_g_2d = (
+        2./h_pv*numpy.sqrt(numpy.log(2.)/numpy.pi))[:, na] * numpy.exp(
+            -4.*numpy.log(2.)*numpy.square(delta_over_h_pv))
+    profile_l_2d = (
+        2./(numpy.pi*h_pv))[:, na] / (
+            1. + 4.*numpy.square(delta_over_h_pv))
+
+    return eta[:, na] * profile_l_2d + (1.-eta)[:, na] * profile_g_2d
+
+
 
 inv_8ln2 = 0.18033688011112042591999058512524
 
@@ -244,23 +262,42 @@ def calc_peak_shape_function(alphas, betas, sigmas,
     z = (beta * sigma**2 - DELTA)/(sigma * 2**0.5)
     DELTA = time - time_hkl
     """
-    alpha0, alpha1 = alphas[0], alphas[1]
-    beta0, beta1 = betas[0], betas[1]
-    alpha = alpha0 + alpha1 / d
-    beta = beta0 + beta1 / d**4
+    sigma0, sigma1, sigma2 = sigmas[0], sigmas[1], sigmas[2]
 
-    if peak_shape == "Gauss":
-        sigma0, sigma1, sigma2 = sigmas[0], sigmas[1], sigmas[2]
-        sigma = calc_sigma(d, sigma0, sigma1, sigma2, size_g=size_g, strain_g=strain_g)
-        res_2d = tof_Jorgensen(alpha, beta, sigma, time, time_hkl)
-    else:  # peak_shape == "pseudo-Voigt"
-        sigma0, sigma1, sigma2 = sigmas[0], sigmas[1], sigmas[2]
+    if peak_shape == "Gauss" or peak_shape == "pseudo-Voigt":
+        alpha0, alpha1 = alphas[0], alphas[1]
+        beta0, beta1 = betas[0], betas[1]
+        alpha = alpha0 + alpha1 / d
+        beta = beta0 + beta1 / d**4
+
+        if peak_shape == "Gauss":
+            sigma = calc_sigma(
+                d, sigma0, sigma1, sigma2, size_g=size_g, strain_g=strain_g)
+
+            res_2d = tof_Jorgensen(alpha, beta, sigma, time, time_hkl)
+
+        elif peak_shape == "pseudo-Voigt":
+            gamma0, gamma1, gamma2 = gammas[0], gammas[1], gammas[2]
+
+            sigma, gamma = calc_sigma_gamma(
+                d, sigma0, sigma1, sigma2, gamma0,
+                gamma1, gamma2, size_g=size_g, size_l=size_l,
+                strain_g=strain_g, strain_l=strain_l)
+
+            res_2d = tof_Jorgensen_VonDreele(
+                alpha, beta, sigma, gamma, time, time_hkl)
+
+    elif peak_shape == "non-conv-pseudo-Voigt":
         gamma0, gamma1, gamma2 = gammas[0], gammas[1], gammas[2]
-        sigma, gamma = calc_sigma_gamma(
-            d, sigma0, sigma1, sigma2, gamma0,
-            gamma1, gamma2, size_g=size_g, size_l=size_l,
-            strain_g=strain_g, strain_l=strain_l)
 
-        res_2d = tof_Jorgensen_VonDreele(
-            alpha, beta, sigma, gamma, time, time_hkl)
+        sigma, gamma = calc_sigma_gamma(
+            d, sigma0, sigma1, sigma2, gamma0, gamma1, gamma2,
+            size_g=0., size_l=0., strain_g=0., strain_l=0.)
+
+        res_2d = tof_non_convoluted_pseudo_voigt(
+            sigma, gamma, time, time_hkl)
+
+    else:
+        raise ValueError(f"Unknown peak shape: {peak_shape}")
+
     return res_2d

--- a/cryspy/C_item_loop_classes/cl_1_tof_profile.py
+++ b/cryspy/C_item_loop_classes/cl_1_tof_profile.py
@@ -82,7 +82,7 @@ class TOFProfile(ItemN):
                  "alpha2": "{:.5f}"}
 
     # constraints on the parameters
-    D_CONSTRAINTS = {"peak_shape": ["pseudo-Voigt", "Gauss", "type0m"]}
+    D_CONSTRAINTS = {"peak_shape": ["non-conv-pseudo-Voigt", "pseudo-Voigt", "Gauss", "type0m"]}
 
     # default values for the parameters
     D_DEFAULT = {"peak_shape": "pseudo-Voigt"}
@@ -117,6 +117,10 @@ class TOFProfile(ItemN):
         Redefined function to_cif
         """
         d_attributes_peak_shape =  {
+            "non-conv-pseudo-Voigt": [
+                "peak_shape",
+                "sigma0", "sigma1", "sigma2",
+                "gamma0", "gamma1", "gamma2"],
             "pseudo-Voigt": [
                 "peak_shape",
                 "sigma0", "sigma1", "sigma2", "size_g", "strain_g",
@@ -183,7 +187,7 @@ class TOFProfile(ItemN):
                 break
         res["profile_sigmas"] = numpy.array(l_sigma, dtype=float)
         res["flags_profile_sigmas"] = numpy.array(l_sigma_refinement, dtype=float)
-        if peak_shape in ["pseudo-Voigt", "type0m"]:
+        if peak_shape in ["non-conv-pseudo-Voigt", "pseudo-Voigt", "type0m"]:
             l_gamma = []
             l_gamma_refinement = []
             for numb in range(3):

--- a/cryspy/E_data_classes/cl_2_tof.py
+++ b/cryspy/E_data_classes/cl_2_tof.py
@@ -239,12 +239,22 @@ class TOF(DataN):
 
         if "profile_peak_shape" in keys:
             profile_peak_shape = ddict_diffrn["profile_peak_shape"]
-            if profile_peak_shape == "pseudo-Voigt":
+            tof_profile = self.tof_profile
+            setattr(tof_profile, "peak_shape", profile_peak_shape)
+            if profile_peak_shape == "non-conv-pseudo-Voigt":
+                profile_sigmas = ddict_diffrn["profile_sigmas"]
+                profile_gammas = ddict_diffrn["profile_gammas"]
+                setattr(tof_profile, "sigma0", profile_sigmas[0])
+                setattr(tof_profile, "sigma1", profile_sigmas[1])
+                setattr(tof_profile, "sigma2", profile_sigmas[2])
+                setattr(tof_profile, "gamma0", profile_gammas[0])
+                setattr(tof_profile, "gamma1", profile_gammas[1])
+                setattr(tof_profile, "gamma2", profile_gammas[2])
+            elif profile_peak_shape == "pseudo-Voigt":
                 profile_sigmas = ddict_diffrn["profile_sigmas"]
                 profile_alphas = ddict_diffrn["profile_alphas"]
                 profile_betas = ddict_diffrn["profile_betas"]
                 profile_gammas = ddict_diffrn["profile_gammas"]
-                tof_profile = self.tof_profile
                 setattr(tof_profile, "alpha0", profile_alphas[0])
                 setattr(tof_profile, "alpha1", profile_alphas[1])
                 setattr(tof_profile, "beta0", profile_betas[0])
@@ -259,7 +269,6 @@ class TOF(DataN):
                 profile_sigmas = ddict_diffrn["profile_sigmas"]
                 profile_alphas = ddict_diffrn["profile_alphas"]
                 profile_betas = ddict_diffrn["profile_betas"]
-                tof_profile = self.tof_profile
                 setattr(tof_profile, "alpha0", profile_alphas[0])
                 setattr(tof_profile, "alpha1", profile_alphas[1])
                 setattr(tof_profile, "beta0", profile_betas[0])
@@ -273,7 +282,6 @@ class TOF(DataN):
                 profile_sigmas = ddict_diffrn["profile_sigmas"]
                 profile_gammas = ddict_diffrn["profile_gammas"]
                 profile_rs = ddict_diffrn["profile_rs"]
-                tof_profile = self.tof_profile
                 setattr(tof_profile, "alpha1", profile_alphas[0])
                 setattr(tof_profile, "alpha2", profile_alphas[1])
                 setattr(tof_profile, "beta00", profile_betas[0])

--- a/cryspy/__init__.py
+++ b/cryspy/__init__.py
@@ -85,9 +85,10 @@ from cryspy.A_functions_base.function_1_strings import value_error_mark_to_strin
     transform_fraction_with_label_to_string, transform_digits_to_string,\
     transform_r_b_to_string
 
-from cryspy.A_functions_base.powder_diffraction_tof import tof_Jorgensen, \
+from cryspy.A_functions_base.powder_diffraction_tof import \
+    tof_non_convoluted_pseudo_voigt, \
+    tof_Jorgensen, \
     tof_Jorgensen_VonDreele
-
 
 from cryspy.A_functions_base.function_2_crystallography_base import \
     calc_volume_uc_by_abc_cosines,\
@@ -234,6 +235,7 @@ L_FUNCTION = [
     transform_r_b_to_string,
     tof_Jorgensen,
     tof_Jorgensen_VonDreele,
+    tof_non_convoluted_pseudo_voigt,
     calc_volume_uc_by_abc_cosines,
     calc_volume_uc_by_abc_angles,
     calc_inverse_d_by_hkl_abc_cosines,

--- a/cryspy/procedure_rhochi/rhochi_tof.py
+++ b/cryspy/procedure_rhochi/rhochi_tof.py
@@ -196,7 +196,13 @@ def calc_chi_sq_for_tof_by_dictionary(
     flags_phase_ig = dict_tof["flags_phase_ig"]  # IG_phase
 
     profile_peak_shape = dict_tof["profile_peak_shape"]
-    if profile_peak_shape == "pseudo-Voigt":
+    if profile_peak_shape == "non-conv-pseudo-Voigt":
+        profile_sigmas = dict_tof["profile_sigmas"]
+        profile_gammas = dict_tof["profile_gammas"]
+        flag_profile_shape = (
+            numpy.any(dict_tof["flags_profile_sigmas"]) or
+            numpy.any(dict_tof["flags_profile_gammas"]))
+    elif profile_peak_shape == "pseudo-Voigt":
         profile_alphas = dict_tof["profile_alphas"]
         profile_betas = dict_tof["profile_betas"]
         profile_sigmas = dict_tof["profile_sigmas"]
@@ -379,7 +385,12 @@ def calc_chi_sq_for_tof_by_dictionary(
                 flag_use_precalculated_data and not(flag_profile_tof)):
             profile_tof = dict_in_out_phase["profile_tof"]
         else:
-            if profile_peak_shape == "pseudo-Voigt":
+            if profile_peak_shape == "non-conv-pseudo-Voigt":
+                profile_tof = calc_peak_shape_function(
+                    None, None, profile_sigmas,
+                    d, time, time_hkl,
+                    gammas=profile_gammas, peak_shape=profile_peak_shape)
+            elif profile_peak_shape == "pseudo-Voigt":
                 profile_tof = calc_peak_shape_function(
                     profile_alphas, profile_betas, profile_sigmas,
                     d, time, time_hkl,

--- a/tests/test_tof_peak_profiles.py
+++ b/tests/test_tof_peak_profiles.py
@@ -1,0 +1,56 @@
+import numpy
+
+from cryspy.A_functions_base.powder_diffraction_tof import (
+    calc_peak_shape_function,
+    tof_non_convoluted_pseudo_voigt,
+)
+from cryspy.C_item_loop_classes.cl_1_tof_profile import TOFProfile
+
+
+def test_non_convoluted_pseudo_voigt_with_zero_gamma_is_gaussian():
+    time = numpy.linspace(-3., 3., 41)
+    time_hkl = numpy.array([0.25])
+    sigma = numpy.array([0.9])
+    gamma = numpy.array([0.])
+
+    actual = tof_non_convoluted_pseudo_voigt(sigma, gamma, time, time_hkl)
+    delta_t = time[:, numpy.newaxis] - time_hkl[numpy.newaxis, :]
+    expected = numpy.exp(-0.5*numpy.square(delta_t/sigma)) / (
+        numpy.sqrt(2.*numpy.pi)*sigma)
+
+    numpy.testing.assert_allclose(actual, expected, rtol=1e-14, atol=1e-14)
+
+
+def test_non_convoluted_pseudo_voigt_uses_sigma_gamma_without_alpha_beta():
+    time = numpy.linspace(-3., 3., 41)
+    time_hkl = numpy.array([0.25])
+    d = numpy.array([1.])
+    sigmas = numpy.array([0.81, 0., 0.])
+    gammas = numpy.array([0.35, 0., 0.])
+
+    actual = calc_peak_shape_function(
+        None, None, sigmas, d, time, time_hkl,
+        gammas=gammas, peak_shape="non-conv-pseudo-Voigt")
+    expected = tof_non_convoluted_pseudo_voigt(
+        numpy.array([0.9]), numpy.array([0.35]), time, time_hkl)
+
+    numpy.testing.assert_allclose(actual, expected, rtol=1e-14, atol=1e-14)
+
+
+def test_tof_profile_dictionary_non_convoluted_pseudo_voigt_has_no_alpha_beta():
+    profile = TOFProfile(
+        peak_shape="non-conv-pseudo-Voigt",
+        sigma0=0.81,
+        sigma1=0.,
+        sigma2=0.,
+        gamma0=0.35,
+        gamma1=0.,
+        gamma2=0.,
+    )
+
+    profile_dict = profile.get_dictionary()
+
+    assert "profile_sigmas" in profile_dict
+    assert "profile_gammas" in profile_dict
+    assert "profile_alphas" not in profile_dict
+    assert "profile_betas" not in profile_dict


### PR DESCRIPTION
## Summary

This PR adds a simple symmetric TOF peak-shape option, `non-conv-pseudo-Voigt`.

The new profile is intended for cases where a direct pseudo-Voigt in TOF space is sufficient and an asymmetric TOF convolution is unnecessary.

## Motivation

This peak shape is not meant to be the general choice for real spallation-source data, where source-pulse asymmetry is usually important and a convoluted TOF profile is more appropriate.

The main use cases here are:

- McStas simulations with simple symmetric peak shapes
- synthetic data and regression tests
- fast exploratory fits where only Gaussian and Lorentzian broadening are needed

For these cases, the non-convoluted profile is attractive because it is simpler and significantly faster to evaluate than the convoluted TOF profiles.

## What is added

- a new TOF peak-shape mode: `non-conv-pseudo-Voigt`
- direct calculation from:
  - `sigma0`, `sigma1`, `sigma2`
  - `gamma0`, `gamma1`, `gamma2`
- integration into TOF profile handling and TOF chi-square calculation
- focused tests for the new profile branch

## Notes

This profile is a direct symmetric pseudo-Voigt in TOF space. It does not include moderator/source asymmetry terms such as the back-to-back exponential convolution used in the Jorgensen / Jorgensen-von Dreele TOF peak shapes.

That limitation is intentional: the goal is a minimal and fast profile model for simple simulated or controlled cases.
