### PR TITLE
Fix TOF thermal dtt2=0 handling and pseudo-Voigt profile math

### DIFF
--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -135,8 +135,11 @@ def tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl):
     z1_2d = alpha[:, na]*delta_2d + (1j*0.5*alpha*gamma)[:, na]
     z2_2d = -beta[:, na]*delta_2d + (1j*0.5*beta*gamma)[:, na]
 
-    fz1_2d = exp1(z1_2d)
-    fz2_2d = exp1(z2_2d)
+    # The Lorentzian term is exp(z) * E1(z); omitting exp(z) breaks
+    # the pseudo-Voigt tails for non-zero gamma.
+    with numpy.errstate(over='ignore', invalid='ignore'):
+        fz1_2d = exp(z1_2d) * exp1(z1_2d)
+        fz2_2d = exp(z2_2d) * exp1(z2_2d)
 
     # FIXME: check it
     fz1_2d[numpy.isnan(fz1_2d)] = 0.

--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -63,10 +63,8 @@ def calc_d_min_max_by_time_thermal_neutrons(time, zero, dtt1, dtt2):
     zero, dtt1, dtt2 = zero.squeeze(), dtt1.squeeze(), dtt2.squeeze()
     time_min = numpy.min(time)
     time_max = numpy.max(time)
-    det_sq_min = numpy.square(dtt1) - 4.* dtt2*(zero - time_min)
-    det_sq_max = numpy.square(dtt1) - 4.* dtt2*(zero - time_max)
-    d_max = (-dtt1+numpy.sqrt(det_sq_max))/(2.*dtt2)
-    d_min = (-dtt1+numpy.sqrt(det_sq_min))/(2.*dtt2)
+    d_min = calc_d_by_time_for_thermal_neutrons(time_min, zero, dtt1, dtt2)
+    d_max = calc_d_by_time_for_thermal_neutrons(time_max, zero, dtt1, dtt2)
     return numpy.stack([d_min, d_max], axis=0)
 
 def calc_d_min_max_by_time_epithermal_neutrons(time, zero, dtt1, zerot, dtt1t, dtt2t):

--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -115,7 +115,7 @@ def tof_Jorgensen(alpha, beta, sigma, time, time_hkl):
 
 
 def tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl):
-    two_over_pi = 2.*numpy.pi
+    two_over_pi = 2./numpy.pi
     norm = 0.5*alpha*beta/(alpha+beta)
     time_2d, time_hkl_2d = numpy.meshgrid(time, time_hkl, indexing="ij")
     delta_2d = time_2d-time_hkl_2d

--- a/cryspy/C_item_loop_classes/cl_1_tof_parameters.py
+++ b/cryspy/C_item_loop_classes/cl_1_tof_parameters.py
@@ -154,10 +154,8 @@ epithermal neutrons")
             d_min = (time_min-self.zero)/self.dtt1
             d_max = (time_max-self.zero)/self.dtt1
         else:  # self.neutrons == "thermal"
-            det_sq_min = self.dtt1**2 - 4.*self.dtt2*(self.zero - time_min)
-            det_sq_max = self.dtt1**2 - 4.*self.dtt2*(self.zero - time_max)
-            d_max = (-self.dtt1+det_sq_max**0.5)/(2.*self.dtt2)
-            d_min = (-self.dtt1+det_sq_min**0.5)/(2.*self.dtt2)
+            d_min = self.calc_d_by_time(time_min)
+            d_max = self.calc_d_by_time(time_max)
         return d_min, d_max
     
     def calc_d_by_time(self, time):

--- a/tests/test_tof_peak_profiles.py
+++ b/tests/test_tof_peak_profiles.py
@@ -1,0 +1,75 @@
+import numpy
+import scipy.special
+
+from cryspy.A_functions_base.powder_diffraction_tof import (
+    calc_d_min_max_by_time_thermal_neutrons,
+    calc_hpv_eta,
+    tof_Jorgensen,
+    tof_Jorgensen_VonDreele,
+)
+from cryspy.C_item_loop_classes.cl_1_tof_parameters import TOFParameters
+
+
+def test_calc_d_min_max_by_time_thermal_neutrons_supports_zero_dtt2():
+    time = numpy.array([3000.0, 19000.0], dtype=float)
+    zero = numpy.array([2.921], dtype=float)
+    dtt1 = numpy.array([6167.247], dtype=float)
+    dtt2 = numpy.array([0.0], dtype=float)
+
+    d_min_max = calc_d_min_max_by_time_thermal_neutrons(time, zero, dtt1, dtt2)
+
+    expected = numpy.array([
+        (time.min() - zero[0]) / dtt1[0],
+        (time.max() - zero[0]) / dtt1[0],
+    ], dtype=float)
+    numpy.testing.assert_allclose(d_min_max, expected)
+
+    tof_parameters = TOFParameters(
+        zero=float(zero[0]),
+        dtt1=float(dtt1[0]),
+        dtt2=float(dtt2[0]),
+        ttheta_bank=145.0,
+    )
+    numpy.testing.assert_allclose(tof_parameters.calc_d_min_max(time), expected)
+
+
+def _expected_lorentz_profile(alpha, beta, gamma, time, time_hkl):
+    norm = 0.5 * alpha * beta / (alpha + beta)
+    time_2d, time_hkl_2d = numpy.meshgrid(time, time_hkl, indexing="ij")
+    delta_2d = time_2d - time_hkl_2d
+
+    z1_2d = alpha[:, numpy.newaxis] * delta_2d + (0.5j * alpha * gamma)[:, numpy.newaxis]
+    z2_2d = -beta[:, numpy.newaxis] * delta_2d + (0.5j * beta * gamma)[:, numpy.newaxis]
+
+    with numpy.errstate(over="ignore", invalid="ignore"):
+        term_1 = numpy.exp(z1_2d) * scipy.special.exp1(z1_2d)
+        term_2 = numpy.exp(z2_2d) * scipy.special.exp1(z2_2d)
+
+    term_1[numpy.isnan(term_1)] = 0.0
+    term_1[numpy.isinf(term_1)] = 0.0
+    term_2[numpy.isnan(term_2)] = 0.0
+    term_2[numpy.isinf(term_2)] = 0.0
+
+    return -2.0 * norm[:, numpy.newaxis] * (
+        numpy.imag(term_1) + numpy.imag(term_2)
+    ) / numpy.pi
+
+
+def test_tof_jorgensen_von_dreele_matches_expected_lorentz_term():
+    alpha = numpy.array([0.4], dtype=float)
+    beta = numpy.array([0.2], dtype=float)
+    sigma = numpy.array([10.0], dtype=float)
+    gamma = numpy.array([5.0], dtype=float)
+    time = numpy.linspace(-50.0, 50.0, 11)
+    time_hkl = numpy.array([0.0], dtype=float)
+
+    actual = tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl)
+
+    gaussian = tof_Jorgensen(alpha, beta, sigma, time, time_hkl)
+    _, eta = calc_hpv_eta(sigma, gamma)
+    lorentz = _expected_lorentz_profile(alpha, beta, gamma, time, time_hkl)
+    expected = (1.0 - eta)[:, numpy.newaxis] * gaussian + eta[:, numpy.newaxis] * lorentz
+
+    numpy.testing.assert_allclose(actual, expected)
+    assert numpy.isfinite(actual).all()
+    assert numpy.all(actual >= 0.0)


### PR DESCRIPTION
Fix the thermal TOF case when `dtt2 = 0`, and correct the `pseudo-Voigt` profile calculation in `tof_Jorgensen_VonDreele`.

#### Changes

1. Reuse `calc_d_by_time_for_thermal_neutrons` in `calc_d_min_max_by_time_thermal_neutrons`
   This fixes the thermal neutron case when `dtt2 = 0`.
   Before this change, `d_min` and `d_max` were still calculated with the quadratic formula and divided by `2*dtt2`. When `dtt2` was zero, this gave `NaN` and could stop reflections from being generated.

2. Fix `two_over_pi` in `tof_Jorgensen_VonDreele`
   Change `two_over_pi` from `2*pi` to `2/pi` so the Lorentzian part has the correct scale.
   See, https://journals.iucr.org/j/issues/2024/05/00/in5102/

3. Add the missing `exp(z) * E1(z)` term in `tof_Jorgensen_VonDreele`
   The Lorentzian part should use `exp(z) * E1(z)`.
   Without `exp(z)`, the `pseudo-Voigt` profile is wrong when `gamma` is not zero, especially in the tails and peak intensity.

   The `with numpy.errstate(over='ignore', invalid='ignore'):` block is used on purpose.
   This calculation can produce overflow or invalid intermediate values in the far tails. These warnings are expected here, so they are ignored, and any non-finite values are then replaced with zero before the final profile is built.

4. Reuse existing `calc_d_by_time` in `TOFParameters.calc_d_min_max`
   This makes the object-level calculation follow the same logic as the shared thermal TOF helper and fixes the same `dtt2 = 0` problem there.
