### PR TITLE
Fix TOF Jorgensen-Von Dreele profile to use one pseudo-Voigt FWHM

### DIFF
--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -118,11 +118,15 @@ def tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl):
     time_2d, time_hkl_2d = numpy.meshgrid(time, time_hkl, indexing="ij")
     delta_2d = time_2d-time_hkl_2d
 
-    # FIXME: it has to be checked
-    # sigma = gamma*(inv_8ln2)**0.5
-    h_pv, eta = calc_hpv_eta(sigma, gamma)
+    # Match FullProf/CrysFML: build one Thompson-Cox-Hastings pseudo-Voigt
+    # FWHM from the Gaussian FWHM and Lorentzian FWHM, then use that common
+    # width for both the Gaussian and Lorentzian components.
+    h_g_fwhm = sigma*numpy.sqrt(8.*numpy.log(2.))
+    h_pv, eta = calc_hpv_eta(h_g_fwhm, gamma)
+    sigma_c = h_pv*numpy.sqrt(inv_8ln2)
+    gamma_c = h_pv
 
-    y, z, u, v = calc_y_z_u_v(alpha, beta, sigma, delta_2d)
+    y, z, u, v = calc_y_z_u_v(alpha, beta, sigma_c, delta_2d)
 
     with numpy.errstate(over='ignore'):
         exp_u = exp(u)
@@ -132,8 +136,8 @@ def tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl):
 
     profile_g_2d = norm[:, na] * (exp_u * erfc(y) + exp_v * erfc(z))
 
-    z1_2d = alpha[:, na]*delta_2d + (1j*0.5*alpha*gamma)[:, na]
-    z2_2d = -beta[:, na]*delta_2d + (1j*0.5*beta*gamma)[:, na]
+    z1_2d = alpha[:, na]*delta_2d + (1j*0.5*alpha*gamma_c)[:, na]
+    z2_2d = -beta[:, na]*delta_2d + (1j*0.5*beta*gamma_c)[:, na]
 
     # The Lorentzian term is exp(z) * E1(z); omitting exp(z) breaks
     # the pseudo-Voigt tails for non-zero gamma.

--- a/tests/functional/test_pr1_jvd_shape.py
+++ b/tests/functional/test_pr1_jvd_shape.py
@@ -1,0 +1,44 @@
+"""Tests for the TOF Jorgensen-Von Dreele single-FWHM fix."""
+
+import numpy as np
+
+from cryspy.A_functions_base.powder_diffraction_tof import (
+    tof_Jorgensen,
+    tof_Jorgensen_VonDreele,
+)
+
+
+_NPTS = 401
+_TIME = np.linspace(-200.0, 200.0, _NPTS)
+_TIME_HKL = np.array([0.0])
+_ALPHA = np.full(_NPTS, 0.5)
+_BETA = np.full(_NPTS, 0.05)
+_SIGMA = np.full(_NPTS, 20.0)
+
+
+def test_jvd_reduces_to_gaussian_at_zero_gamma():
+    gauss = tof_Jorgensen(_ALPHA, _BETA, _SIGMA, _TIME, _TIME_HKL)
+    jvd = tof_Jorgensen_VonDreele(
+        _ALPHA, _BETA, _SIGMA, np.zeros(_NPTS), _TIME, _TIME_HKL
+    )
+    np.testing.assert_allclose(jvd, gauss, rtol=1e-10, atol=1e-12)
+
+
+def test_jvd_has_lorentzian_wings_for_nonzero_gamma():
+    gauss = tof_Jorgensen(_ALPHA, _BETA, _SIGMA, _TIME, _TIME_HKL)
+    jvd = tof_Jorgensen_VonDreele(
+        _ALPHA, _BETA, _SIGMA, np.full(_NPTS, 15.0), _TIME, _TIME_HKL
+    )
+    far = np.abs(_TIME) > 120.0
+    assert jvd[far].max() > 2.0 * gauss[far].max()
+
+
+def test_jvd_golden_values_single_tch_fwhm():
+    jvd = tof_Jorgensen_VonDreele(
+        _ALPHA, _BETA, _SIGMA, np.full(_NPTS, 15.0), _TIME, _TIME_HKL
+    )
+    idx = [180, 200, 220, 260]
+    expected = [0.00587542, 0.01106804, 0.01189444, 0.00408059]
+    np.testing.assert_allclose(
+        [jvd[i, 0] for i in idx], expected, rtol=1e-5
+    )

--- a/tests/functional/test_tof_peak_profiles.py
+++ b/tests/functional/test_tof_peak_profiles.py
@@ -68,9 +68,11 @@ def test_tof_jorgensen_von_dreele_matches_expected_lorentz_term():
 
     actual = tof_Jorgensen_VonDreele(alpha, beta, sigma, gamma, time, time_hkl)
 
-    gaussian = tof_Jorgensen(alpha, beta, sigma, time, time_hkl)
-    _, eta = calc_hpv_eta(sigma, gamma)
-    lorentz = _expected_lorentz_profile(alpha, beta, gamma, time, time_hkl)
+    h_g_fwhm = sigma * numpy.sqrt(8.0 * numpy.log(2.0))
+    h_pv, eta = calc_hpv_eta(h_g_fwhm, gamma)
+    sigma_c = h_pv / numpy.sqrt(8.0 * numpy.log(2.0))
+    gaussian = tof_Jorgensen(alpha, beta, sigma_c, time, time_hkl)
+    lorentz = _expected_lorentz_profile(alpha, beta, h_pv, time, time_hkl)
     expected = (1.0 - eta)[:, numpy.newaxis] * gaussian + eta[:, numpy.newaxis] * lorentz
 
     numpy.testing.assert_allclose(actual, expected)


### PR DESCRIPTION
The TOF pseudo-Voigt (Jorgensen-Von Dreele) mixes a Gaussian part and a Lorentzian part. The standard Thompson-Cox-Hastings (TCH) method, used by FullProf/CrysFML, GSAS, Mantid, builds **one** combined width `H` from the Gaussian FWHM and the Lorentzian FWHM, and uses that **same** `H` for both parts. 

cryspy did two things:
1. It fed the Gaussian **standard deviation** into the TCH mixing, but TCH needs the Gaussian **FWHM** (`FWHM = sigma * sqrt(8 ln 2)`).
2. It used the Gaussian width for the Gaussian part and the Lorentzian width for the Lorentzian part **separately**, instead of the one combined `H`. (It even computed `H` and then threw it away.)

Because of this, a non-zero Lorentzian term gave the wrong shape, and refining it did not help (issue #49). cryspy even had a `# FIXME: it has to be checked` comment on the exact wrong line.

https://docs.mantidproject.org/nightly/fitting/fitfunctions/PseudoVoigt.html
https://docs.mantidproject.org/nightly/fitting/fitfunctions/NeutronBk2BkExpConvPVoigt.html

<img width="1690" height="598" alt="pr1_jvd_shape_before_after" src="https://github.com/user-attachments/assets/e5d9356e-e4bd-4cb0-ba5f-fb1b4c27f87c" />
