### PR TITLE
Wire isotropic size/strain coefficients into TOF Gauss and pseudo-Voigt profiles

### DIFF
--- a/cryspy/C_item_loop_classes/cl_1_tof_profile.py
+++ b/cryspy/C_item_loop_classes/cl_1_tof_profile.py
@@ -187,6 +187,16 @@ class TOFProfile(ItemN):
                 break
         res["profile_sigmas"] = numpy.array(l_sigma, dtype=float)
         res["flags_profile_sigmas"] = numpy.array(l_sigma_refinement, dtype=float)
+        for _nm in ("size_g", "strain_g", "size_l", "strain_l"):
+            _value = getattr(self, _nm) if self.is_attribute(_nm) else None
+            if _value is not None:
+                _value = float(_value)
+            if (_value is not None) and numpy.isfinite(_value):
+                res[f"profile_{_nm}"] = numpy.array([_value], dtype=float)
+                res[f"flags_profile_{_nm}"] = numpy.array([getattr(self, f"{_nm}_refinement")], dtype=bool)
+            else:
+                res[f"profile_{_nm}"] = numpy.array([0.0], dtype=float)
+                res[f"flags_profile_{_nm}"] = numpy.array([False], dtype=bool)
         if peak_shape in ["non-conv-pseudo-Voigt", "pseudo-Voigt", "type0m"]:
             l_gamma = []
             l_gamma_refinement = []

--- a/cryspy/procedure_rhochi/rhochi_tof.py
+++ b/cryspy/procedure_rhochi/rhochi_tof.py
@@ -211,7 +211,11 @@ def calc_chi_sq_for_tof_by_dictionary(
             numpy.any(dict_tof["flags_profile_alphas"]) or
             numpy.any(dict_tof["flags_profile_betas"]) or
             numpy.any(dict_tof["flags_profile_sigmas"]) or
-            numpy.any(dict_tof["flags_profile_gammas"]))
+            numpy.any(dict_tof["flags_profile_gammas"]) or
+            numpy.any(dict_tof["flags_profile_size_g"]) or
+            numpy.any(dict_tof["flags_profile_strain_g"]) or
+            numpy.any(dict_tof["flags_profile_size_l"]) or
+            numpy.any(dict_tof["flags_profile_strain_l"]))
     elif profile_peak_shape == "Gauss":
         profile_alphas = dict_tof["profile_alphas"]
         profile_betas = dict_tof["profile_betas"]
@@ -219,7 +223,9 @@ def calc_chi_sq_for_tof_by_dictionary(
         flag_profile_shape = (
             numpy.any(dict_tof["flags_profile_alphas"]) or
             numpy.any(dict_tof["flags_profile_betas"]) or
-            numpy.any(dict_tof["flags_profile_sigmas"]))
+            numpy.any(dict_tof["flags_profile_sigmas"]) or
+            numpy.any(dict_tof["flags_profile_size_g"]) or
+            numpy.any(dict_tof["flags_profile_strain_g"]))
     elif profile_peak_shape == "type0m":
         profile_alphas = dict_tof["profile_alphas"]
         profile_betas = dict_tof["profile_betas"]
@@ -394,14 +400,20 @@ def calc_chi_sq_for_tof_by_dictionary(
                 profile_tof = calc_peak_shape_function(
                     profile_alphas, profile_betas, profile_sigmas,
                     d, time, time_hkl,
-                    gammas=profile_gammas, size_g=0., size_l=0.,
-                    strain_g=0., strain_l=0., peak_shape=profile_peak_shape)
+                    gammas=profile_gammas, size_g=dict_tof.get("profile_size_g", 0.),
+                    size_l=dict_tof.get("profile_size_l", 0.),
+                    strain_g=dict_tof.get("profile_strain_g", 0.),
+                    strain_l=dict_tof.get("profile_strain_l", 0.),
+                    peak_shape=profile_peak_shape)
             elif profile_peak_shape == "Gauss":
                 profile_tof = calc_peak_shape_function(
                     profile_alphas, profile_betas, profile_sigmas,
                     d, time, time_hkl,
-                    gammas=None, size_g=0., size_l=0.,
-                    strain_g=0., strain_l=0., peak_shape=profile_peak_shape)
+                    gammas=None, size_g=dict_tof.get("profile_size_g", 0.),
+                    size_l=dict_tof.get("profile_size_l", 0.),
+                    strain_g=dict_tof.get("profile_strain_g", 0.),
+                    strain_l=dict_tof.get("profile_strain_l", 0.),
+                    peak_shape=profile_peak_shape)
             elif profile_peak_shape == "type0m":
                 time_2d = numpy.expand_dims(time, axis=1)
                 time_hkl_2d = numpy.expand_dims(time_hkl, axis=0)

--- a/tests/functional/test_tof_peak_profiles.py
+++ b/tests/functional/test_tof_peak_profiles.py
@@ -125,3 +125,104 @@ def test_tof_profile_dictionary_non_convoluted_pseudo_voigt_has_no_alpha_beta():
     assert "profile_gammas" in profile_dict
     assert "profile_alphas" not in profile_dict
     assert "profile_betas" not in profile_dict
+
+
+def test_tof_profile_dictionary_exports_size_strain_coefficients():
+    profile = TOFProfile(
+        peak_shape="pseudo-Voigt",
+        sigma0=0.81,
+        sigma1=0.,
+        sigma2=0.,
+        gamma0=0.35,
+        gamma1=0.,
+        gamma2=0.,
+        alpha0=0.,
+        alpha1=0.2971,
+        beta0=0.04182,
+        beta1=0.00224,
+        size_g=0.25,
+        strain_g=0.50,
+        size_l=0.75,
+        strain_l=1.00,
+        size_g_refinement=True,
+        strain_l_refinement=True,
+    )
+
+    profile_dict = profile.get_dictionary()
+
+    numpy.testing.assert_allclose(profile_dict["profile_size_g"], [0.25])
+    numpy.testing.assert_allclose(profile_dict["profile_strain_g"], [0.50])
+    numpy.testing.assert_allclose(profile_dict["profile_size_l"], [0.75])
+    numpy.testing.assert_allclose(profile_dict["profile_strain_l"], [1.00])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_size_g"], [True])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_strain_g"], [False])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_size_l"], [False])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_strain_l"], [True])
+
+
+def test_tof_profile_dictionary_missing_size_strain_defaults_to_zero():
+    profile = TOFProfile(
+        peak_shape="pseudo-Voigt",
+        sigma0=0.81,
+        sigma1=0.,
+        sigma2=0.,
+        gamma0=0.35,
+        gamma1=0.,
+        gamma2=0.,
+        alpha0=0.,
+        alpha1=0.2971,
+        beta0=0.04182,
+        beta1=0.00224,
+        size_g=None,
+        strain_g=None,
+    )
+
+    profile_dict = profile.get_dictionary()
+
+    numpy.testing.assert_allclose(profile_dict["profile_size_g"], [0.])
+    numpy.testing.assert_allclose(profile_dict["profile_strain_g"], [0.])
+    numpy.testing.assert_allclose(profile_dict["profile_size_l"], [0.])
+    numpy.testing.assert_allclose(profile_dict["profile_strain_l"], [0.])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_size_g"], [False])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_strain_g"], [False])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_size_l"], [False])
+    numpy.testing.assert_array_equal(profile_dict["flags_profile_strain_l"], [False])
+
+
+def test_tof_size_strain_coefficients_match_sigma_gamma_paths():
+    time = numpy.linspace(-3., 3., 41)
+    time_hkl = numpy.array([0.25])
+    d = numpy.array([1.2])
+    alphas = numpy.array([0.4, 0.])
+    betas = numpy.array([0.2, 0.])
+
+    sigmas = numpy.array([0.81, 0.10, 0.20])
+    size_g = numpy.array([0.05])
+    strain_g = numpy.array([0.07])
+
+    actual_gauss = calc_peak_shape_function(
+        alphas, betas, sigmas, d, time, time_hkl,
+        gammas=None, size_g=size_g, strain_g=strain_g,
+        peak_shape="Gauss")
+    expected_gauss = calc_peak_shape_function(
+        alphas, betas,
+        numpy.array([sigmas[0], sigmas[1] + strain_g[0], sigmas[2] + size_g[0]]),
+        d, time, time_hkl, gammas=None, peak_shape="Gauss")
+
+    gammas = numpy.array([0.35, 0.04, 0.03])
+    size_l = numpy.array([0.06])
+    strain_l = numpy.array([0.08])
+
+    actual_pv = calc_peak_shape_function(
+        alphas, betas, sigmas, d, time, time_hkl,
+        gammas=gammas, size_g=size_g, strain_g=strain_g,
+        size_l=size_l, strain_l=strain_l, peak_shape="pseudo-Voigt")
+    expected_pv = calc_peak_shape_function(
+        alphas, betas,
+        numpy.array([sigmas[0], sigmas[1] + strain_g[0], sigmas[2] + size_g[0]]),
+        d, time, time_hkl,
+        gammas=numpy.array([gammas[0], gammas[1] + strain_l[0], gammas[2] + size_l[0]]),
+        peak_shape="pseudo-Voigt")
+
+    numpy.testing.assert_allclose(actual_gauss, expected_gauss)
+    numpy.testing.assert_allclose(actual_pv, expected_pv)


### PR DESCRIPTION
The TOF profile item already had `size_g`, `strain_g`, `size_l` and
`strain_l` attributes, and the low-level TOF peak-shape code already
accepted them.

But these values were not wired into the rhochi TOF path. The profile
dictionary did not export them, and `rhochi_tof.py` always passed fixed
zeros to the profile calculation. So setting them had no effect.

This PR wires the isotropic size/strain coefficients into the TOF
calculation dictionary and passes them to `calc_peak_shape_function()` for
the `Gauss` and `pseudo-Voigt` peak shapes.

The cryspy coefficients are raw additive terms:

`H_G^2 = (sigma2 + size_g) * d^4 + (sigma1 + strain_g) * d^2 + sigma0`

`H_L = (gamma2 + size_l) * d^2 + (gamma1 + strain_l) * d + gamma0`

The refine flags are also exported and included in the cached-profile
invalidation path. This prepares the dictionary/profile infrastructure for
these parameters, consistent with the rest of cryspy.