### PR TITLE
Add release-draft and workflow-runs cleanup CI

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,79 @@
+# Delete old workflow runs on a schedule (or manually) to keep the
+# Actions history tidy.
+# https://github.com/Mattraks/delete-workflow-runs
+
+name: Old workflow runs cleanup
+
+on:
+  # Run monthly, at 00:00 on the 1st day of the month.
+  schedule:
+    - cron: '0 0 1 * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days.'
+        required: true
+        default: '30'
+      minimum_runs:
+        description: 'The minimum runs to keep for each workflow.'
+        required: true
+        default: '6'
+      delete_workflow_pattern:
+        description:
+          'The name or filename of the workflow. If not set then it will target all
+          workflows.'
+        required: false
+      delete_workflow_by_state_pattern:
+        description:
+          'Remove workflow by state: active, deleted, disabled_fork,
+          disabled_inactivity, disabled_manually'
+        required: true
+        default: 'All'
+        type: choice
+        options:
+          - 'All'
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description:
+          'Remove workflow by conclusion: action_required, cancelled, failure, skipped,
+          success'
+        required: true
+        default: 'All'
+        type: choice
+        options:
+          - 'All'
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: 'Only log actions, do not perform any delete operations (dry run).'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+jobs:
+  del-runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
+          delete_run_by_conclusion_pattern: ${{ github.event.inputs.delete_run_by_conclusion_pattern }}
+          dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,58 @@
+# Drafts the next release notes as pull requests are merged into the
+# default branch, and keeps a GitHub draft release up to date. The next
+# version is computed from the [scope] labels of the merged PRs.
+
+name: Release draft update
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history with tags for the version number
+
+      - name: Draft the next release notes
+        id: draft
+        uses: enhantica/drafterino@v2
+        with:
+          config: |
+            title: 'cryspy $COMPUTED_VERSION'
+            tag: '$COMPUTED_VERSION'
+            note-template: '- $PR_TITLE (#$PR_NUMBER)'
+
+            default-bump: post
+
+            major-bump-labels: ['[scope] significant']
+            minor-bump-labels: ['[scope] enhancement']
+            patch-bump-labels: ['[scope] bug', '[scope] maintenance']
+            post-bump-labels: ['[scope] documentation']
+
+            release-notes:
+              - title: 'Added'
+                labels: ['[scope] significant', '[scope] enhancement']
+              - title: 'Fixed'
+                labels: ['[scope] bug']
+              - title: 'Changed'
+                labels: ['[scope] maintenance', '[scope] documentation']
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub draft release
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          tag_name: ${{ steps.draft.outputs.tag_name }}
+          name: ${{ steps.draft.outputs.release_name }}
+          body: ${{ steps.draft.outputs.release_notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds two maintenance CI workflows (matching easyscience/diffraction-lib):

- **Release draft update** (`release-notes.yml`): on pushes to `master` (or manually), keeps a GitHub **draft release** up to date. The next version and grouped notes (Added/Fixed/Changed) are computed from the `[scope]` labels of merged PRs via `drafterino`. Uses `GITHUB_TOKEN`; tag/title follow cryspy's plain (non-`v`) version scheme.
- **Old workflow runs cleanup** (`cleanup.yml`): monthly (and manual) deletion of old Actions runs via `Mattraks/delete-workflow-runs`, with tunable retention inputs.

Both rely only on the default `GITHUB_TOKEN` and the `[scope]`/`[bot]` labels already present in the repo.