### PR TITLE
Fix TOF Lorentz half-angle scale convention

### DIFF
--- a/cryspy/A_functions_base/powder_diffraction_tof.py
+++ b/cryspy/A_functions_base/powder_diffraction_tof.py
@@ -11,15 +11,14 @@ na = numpy.newaxis
 def calc_lorentz_factor(ttheta, flag_ttheta: bool = False):
     """Angular (bank-angle) part of the TOF Lorentz factor.
 
-    Returns ``sin(ttheta)`` for the fixed detector bank angle ``ttheta``
-    (the full scattering angle ``2theta_bank``). The reflection-dependent
-    ``d**4`` part is applied separately, so the complete TOF Lorentz
-    factor is ``d**4 * sin(ttheta)`` (cf. CrysFML ``lorentz = dsp4 * sina``).
+    ``ttheta`` is the full fixed detector angle ``2theta_bank``. The
+    reflection-dependent ``d**4`` part is applied separately, so the complete
+    FullProf/GSAS-style TOF Lorentz factor is ``d**4 * sin(ttheta / 2)``.
     """
-    res = numpy.sin(ttheta)
+    res = numpy.sin(0.5 * ttheta)
     dder = {}
     if flag_ttheta:
-        dder["ttheta"] = numpy.cos(ttheta)
+        dder["ttheta"] = 0.5 * numpy.cos(0.5 * ttheta)
     return res, dder
 
 

--- a/examples/rhochi_unpolarized_tof_powder_CeCuAl/rhochi_unpolarized_tof_powder_CeCuAl.rcif
+++ b/examples/rhochi_unpolarized_tof_powder_CeCuAl/rhochi_unpolarized_tof_powder_CeCuAl.rcif
@@ -88,7 +88,7 @@ loop_
 _phase_label
 _phase_scale
 _phase_igsize
-  cecual   57366.89(2363)   0.0
+  cecual   34501.11(2363)   0.0
 
 loop_
 _tof_meas_time

--- a/tests/functional/test_tof/model_gauss.rcif
+++ b/tests/functional/test_tof/model_gauss.rcif
@@ -85,7 +85,7 @@ loop_
 _phase_label
 _phase_scale
 _phase_igsize
-  cecual   56604.12(2363)   0.0
+  cecual   34042.37(2363)   0.0
 
 loop_
 _tof_meas_time

--- a/tests/functional/test_tof/model_pV.rcif
+++ b/tests/functional/test_tof/model_pV.rcif
@@ -90,7 +90,7 @@ loop_
 _phase_label
 _phase_scale
 _phase_igsize
-  cecual   56604.12(2363)   0.0
+  cecual   34042.37(2363)   0.0
 
 loop_
 _tof_meas_time

--- a/tests/functional/test_tof_peak_profiles.py
+++ b/tests/functional/test_tof_peak_profiles.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 import scipy.special
 
 from cryspy.A_functions_base.powder_diffraction_tof import (
@@ -140,7 +141,8 @@ def test_tof_profile_dictionary_non_convoluted_pseudo_voigt_has_no_alpha_beta():
     assert "profile_betas" not in profile_dict
 
 
-def test_rhochi_tof_lorentz_factor_uses_bank_half_angle(monkeypatch):
+@pytest.mark.parametrize("profile_peak_shape", ["Gauss", "pseudo-Voigt"], ids=["Jorgensen", "JvD"])
+def test_rhochi_tof_lorentz_factor_uses_bank_half_angle(monkeypatch, profile_peak_shape):
     from cryspy.procedure_rhochi import rhochi_tof
 
     time = numpy.array([1.0, 2.0, 3.0], dtype=float)
@@ -211,13 +213,15 @@ def test_rhochi_tof_lorentz_factor_uses_bank_half_angle(monkeypatch):
         "phase_ig": numpy.array([0.0], dtype=float),
         "flags_phase_scale": numpy.array([False], dtype=bool),
         "flags_phase_ig": numpy.array([False], dtype=bool),
-        "profile_peak_shape": "Gauss",
+        "profile_peak_shape": profile_peak_shape,
         "profile_alphas": numpy.array([0.0, 0.0], dtype=float),
         "profile_betas": numpy.array([0.0, 0.0], dtype=float),
         "profile_sigmas": numpy.array([1.0, 0.0, 0.0], dtype=float),
+        "profile_gammas": numpy.array([0.1, 0.0, 0.0], dtype=float),
         "flags_profile_alphas": numpy.array([False, False], dtype=bool),
         "flags_profile_betas": numpy.array([False, False], dtype=bool),
         "flags_profile_sigmas": numpy.array([False, False, False], dtype=bool),
+        "flags_profile_gammas": numpy.array([False, False, False], dtype=bool),
         "profile_size_g": numpy.array([0.0], dtype=float),
         "profile_strain_g": numpy.array([0.0], dtype=float),
         "profile_size_l": numpy.array([0.0], dtype=float),

--- a/tests/functional/test_tof_peak_profiles.py
+++ b/tests/functional/test_tof_peak_profiles.py
@@ -37,13 +37,14 @@ def test_calc_d_min_max_by_time_thermal_neutrons_supports_zero_dtt2():
     numpy.testing.assert_allclose(tof_parameters.calc_d_min_max(time), expected)
 
 
-def test_tof_lorentz_factor_uses_bank_angle():
-    ttheta_bank = numpy.deg2rad(numpy.array([60.0, 100.0], dtype=float))
+def test_tof_lorentz_factor_uses_bank_half_angle():
+    ttheta_bank = numpy.deg2rad(numpy.array([152.827], dtype=float))
 
     actual, dder = calc_lorentz_factor(ttheta_bank, flag_ttheta=True)
 
-    numpy.testing.assert_allclose(actual, numpy.sin(ttheta_bank))
-    numpy.testing.assert_allclose(dder["ttheta"], numpy.cos(ttheta_bank))
+    half_ttheta_bank = numpy.deg2rad(numpy.array([152.827 / 2.0], dtype=float))
+    numpy.testing.assert_allclose(actual, numpy.sin(half_ttheta_bank))
+    numpy.testing.assert_allclose(dder["ttheta"], 0.5 * numpy.cos(half_ttheta_bank))
 
 
 def _expected_lorentz_profile(alpha, beta, gamma, time, time_hkl):
@@ -139,7 +140,7 @@ def test_tof_profile_dictionary_non_convoluted_pseudo_voigt_has_no_alpha_beta():
     assert "profile_betas" not in profile_dict
 
 
-def test_rhochi_tof_lorentz_factor_matches_cfml_convention(monkeypatch):
+def test_rhochi_tof_lorentz_factor_uses_bank_half_angle(monkeypatch):
     from cryspy.procedure_rhochi import rhochi_tof
 
     time = numpy.array([1.0, 2.0, 3.0], dtype=float)
@@ -250,11 +251,11 @@ def test_rhochi_tof_lorentz_factor_matches_cfml_convention(monkeypatch):
 
     expected_plus = (
         0.5 * phase_scale * iint_plus * multiplicity *
-        numpy.power(d_hkl, 4) * numpy.sin(ttheta_bank)
+        numpy.power(d_hkl, 4) * numpy.sin(0.5 * ttheta_bank)
     )
     expected_minus = (
         0.5 * phase_scale * iint_minus * multiplicity *
-        numpy.power(d_hkl, 4) * numpy.sin(ttheta_bank)
+        numpy.power(d_hkl, 4) * numpy.sin(0.5 * ttheta_bank)
     )
     dict_phase = dict_in_out["dict_in_out_phase"]
 


### PR DESCRIPTION
This PR changes TOF Lorentz half-angle scale convention.

FullProf and GSAS-II use the TOF absolute-scale convention:

`d^4 * sin(2ThetaBank / 2)`

Cryspy previously used:

`d^4 * sin(2ThetaBank)`

which produced an absolute intensity mismatch for TOF data. CW diffraction is unaffected.

<img width="1980" height="990" alt="TOF FullProf vs cryspy comparison" src="https://github.com/user-attachments/assets/827b3113-5693-4606-80dc-f604e9a87d62" />